### PR TITLE
Pass website provider kwargs through relation, add 'path' param

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -15,9 +15,10 @@ class HttpProvides(RelationBase):
     def broken(self):
         self.remove_state('{relation_name}.available')
 
-    def configure(self, port):
+    def configure(self, port, **kwargs):
         relation_info = {
             'hostname': hookenv.unit_get('private-address'),
             'port': port,
         }
+        relation_info.update(kwargs)
         self.set_remote(**relation_info)

--- a/requires.py
+++ b/requires.py
@@ -33,6 +33,7 @@ class HttpRequires(RelationBase):
                         {
                             'hostname': address_of_host,
                             'port': port_for_host,
+                            'path': path_for_proxying_host,
                         },
                         # ...
                     ],
@@ -47,11 +48,13 @@ class HttpRequires(RelationBase):
                 'service_name': service_name,
                 'hosts': [],
             })
-            host = conv.get_remote('hostname') or conv.get_remove('private-address')
+            host = conv.get_remote('hostname') or conv.get_remote('private-address')
             port = conv.get_remote('port')
+            path = conv.get_remote('path')
             if host and port:
                 service['hosts'].append({
                     'hostname': host,
                     'port': port,
+                    'path': path,
                 })
         return [s for s in services.values() if s['hosts']]


### PR DESCRIPTION
I think it'd be nice if charms that provide the website endpoint could specify to the reverseproxy endpoint the path under which they'd like to be located. I just don't like messing with rewrite rules. They're not hard, but they're always a hassle to look up.

For an example charm with a reverseproxy that supports the path relation setting, see https://github.com/cmars/nginx-layer. This charm is great for development -- I'm using it to reverseproxy and route a bunch of microservices behind a single HTTP endpoint. Doesn't support load-balancing yet, but I bet there's a way to do it by grouping the units by path or something.

Passing custom kwargs through allows the website endpoint to also provide compatibility with charms that do relation setting of chunks of yaml for complex stuff, like haproxy, etc.
