### PR TITLE
hostname and private-address as optional parameters to configure_website()

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -15,9 +15,14 @@ class HttpProvides(RelationBase):
     def broken(self):
         self.remove_state('{relation_name}.available')
 
-    def configure(self, port):
+    def configure(self, port, private_address=None, hostname=None):
+        if not hostname:
+            hostname = hookenv.unit_get('private-address')
+        if not private_address:
+            private_address = hookenv.unit_get('private-address')
         relation_info = {
-            'hostname': hookenv.unit_get('private-address'),
+            'hostname': hostname,
+            'private-address': private_address,
             'port': port,
         }
         self.set_remote(**relation_info)


### PR DESCRIPTION
Some charms are proxies for other charms. Examples of this are charms that
deploy docker containers on an external docker host, or charms that manage an
externally hosted service.

The machine where the Juju agent of a proxy charm runs might not be the machine
where the actual application is running. For this reason, proxy charms might
want to supply a custom hostname and private address. This patch makes that
possible.