### PR TITLE
back compat method for charms calling RelationBase.set_remote

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -28,3 +28,14 @@ class HttpProvides(Endpoint):
                 'private-address': private_address or ingress_address,
                 'port': port,
             })
+
+    def set_remote(self, **kwargs):
+        # NB: This method provides backwards compatibility for charms that
+        # called RelationBase.set_remote. Most commonly, this was done by
+        # charms that needed to pass reverse proxy stanzas to http proxies.
+        # This type of interaction with base relation classes is discouraged,
+        # and should be handled with logic encapsulated in appropriate
+        # interfaces. Eventually, this method will be deprecated in favor of
+        # that behavior.
+        for relation in self.relations:
+            relation.to_publish_raw.update(kwargs)


### PR DESCRIPTION
@johnsca in thinking about the issue with #10, the only charms i can find that break interface encapsulation (that is, they call the old `RelationBase.set_remote()` directly) are reverse proxy providers that try to ship `services` yaml over to things like apache2/haproxy.

As discussed, these will break with the endpoint transition.  I think the permanent solution for them would be to have a new interface specifically for rev proxies.  We talked about a proper rev proxy method in the http interface, but that feels to me like turning the simple http interface into a kitchen sink (what's next, interface-http provides basic auth too?).

In the short term, how do you feel about this proposed simple method that maintains back compat by letting charms dump kwargs over this interface?

The pros for this is that we can make the switch to Endpoints quickly and no charms need to change. The con is that we introduce a new method that we will need to deprecate later.

One alternative would be to go ahead and write a new rev proxy interface, alter charms like graylog to use it, and then proceed with #10 as is.  Got a feeling one way or another?