### PR TITLE
Need to return a stable list of service hosts

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -69,7 +69,7 @@ class HttpRequires(Endpoint):
 
             service['hosts'] = [
                 {'hostname': h, 'private-address': pa, 'port': p}
-                for h, pa, p in host_set
+                for h, pa, p in sorted(host_set)
             ]
 
         ret = [s for s in services.values() if s['hosts']]


### PR DESCRIPTION
Noticed that kubelet was being restarted almost every hook and figured out the list of http endpoints to the api servers was changing order. This makes that return a stable list.